### PR TITLE
feat: 월별 기준금리 1년 단위로 통합, 한국-미국 연평균 금리차 계산

### DIFF
--- a/src/crawling/economic_index/한국은행 API크롤러.ipynb
+++ b/src/crawling/economic_index/한국은행 API크롤러.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,32 +53,71 @@
     "# 생산자물가지수 연평균, 2015년 PPI를 100으로 함.\n",
     "param_PPI = ['404Y014', 'A', 2018, 2022, '*AA']\n",
     "\n",
-    "# 국고채 3년물 금리 일단위 -> 집계필요\n",
-    "param_kor_govrn_3ybond = ['817Y002', 'D', 20180101, 20221231, '010200000'] \n",
     "\n",
     "# 한국 정책금리 월단위\n",
     "param_kr_policyratio = ['902Y006', 'M', 201801, 202212, 'KR']\n",
     "# 미국 정책금리 월단위\n",
     "param_us_policyratio = ['902Y006', 'M', 201801, 202212, 'US']\n",
+    "\n",
     "# # 한국은행 기준금리 일단위\n",
-    "# param_kor_standard_yield = ['722Y001', 'D', 20180101, 20221231, '0101000']\n"
+    "# param_kor_standard_yield = ['722Y001', 'D', 20180101, 20221231, '0101000']\n",
+    "# # 국고채 3년물 금리 일단위 -> 집계필요\n",
+    "# param_kor_govrn_3ybond = ['817Y002', 'D', 20180101, 20221231, '010200000'] "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# 환율, 통화량, 생산자 물가지수 연평균\n",
     "df_uskor_exchange = get_bok_df(*param_uskor_exchange)\n",
     "df_m2 = get_bok_df(*param_m2)\n",
-    "df_uskor_exchange = get_bok_df(*param_PPI)\n",
+    "df_PPI = get_bok_df(*param_PPI)\n",
     "\n",
-    "df_kor_govrn_3ybond = get_bok_df(*param_kor_govrn_3ybond)\n",
+    "# 월단위 정책금리\n",
     "df_kr_policyratio  = get_bok_df(*param_kr_policyratio)\n",
-    "df_us_policyratio = get_bok_df(*param_us_policyratio)\n",
+    "df_us_policyratio = get_bok_df(*param_us_policyratio)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_kr_policyratio['TIME'] = pd.to_datetime(df_kr_policyratio['TIME'], format='%Y%m')\n",
+    "df_kr_policyratio['YEAR'] = df_kr_policyratio['TIME'].dt.year\n",
+    "df_kr_policyratio['DATA_VALUE'] = df_kr_policyratio['DATA_VALUE'].astype(float)\n",
+    "kr_year_policyratio = df_kr_policyratio.groupby('YEAR')['DATA_VALUE'].mean().round(4)\n",
     "\n",
-    "df_list = [df_uskor_exchange, df_m2, df_uskor_exchange, df_kor_govrn_3ybond, df_kr_policyratio, df_us_policyratio]"
+    "df_us_policyratio['TIME'] = pd.to_datetime(df_us_policyratio['TIME'], format='%Y%m')\n",
+    "df_us_policyratio['YEAR'] = df_us_policyratio['TIME'].dt.year\n",
+    "df_us_policyratio['DATA_VALUE'] = df_us_policyratio['DATA_VALUE'].astype(float)\n",
+    "us_year_policyratio = df_us_policyratio.groupby('YEAR')['DATA_VALUE'].mean().round(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 한국정책금리 - 미국정책금리 -> 양수값이 나오면 한국정책금리 > 미국정책금리\n",
+    "kr_minus_us_policyratio = kr_year_policyratio - us_year_policyratio\n",
+    "df_kr_minus_us_policyratio = pd.DataFrame({'YEAR': kr_minus_us_policyratio.index, 'KR MINUS US RATE': kr_minus_us_policyratio.values})\n",
+    "\n",
+    "# # 결과 출력\n",
+    "# print(df_kr_minus_us_policyratio)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DB로 전송 코드"
    ]
   },
   {
@@ -119,10 +158,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'pythondf_to_DB' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32mc:\\Users\\USER_20211027\\Desktop\\final_project\\github\\Final-Project\\src\\crawling\\economic_index\\한국은행 API크롤러.ipynb 셀 9\u001b[0m in \u001b[0;36m<cell line: 2>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      <a href='vscode-notebook-cell:/c%3A/Users/USER_20211027/Desktop/final_project/github/Final-Project/src/crawling/economic_index/%ED%95%9C%EA%B5%AD%EC%9D%80%ED%96%89%20API%ED%81%AC%EB%A1%A4%EB%9F%AC.ipynb#X36sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39m# 사용할 데이터프레임\u001b[39;00m\n\u001b[1;32m----> <a href='vscode-notebook-cell:/c%3A/Users/USER_20211027/Desktop/final_project/github/Final-Project/src/crawling/economic_index/%ED%95%9C%EA%B5%AD%EC%9D%80%ED%96%89%20API%ED%81%AC%EB%A1%A4%EB%9F%AC.ipynb#X36sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m pythondf_to_DB(df_uskor_exchange, database_name, df_uskor_exchange)\n\u001b[0;32m      <a href='vscode-notebook-cell:/c%3A/Users/USER_20211027/Desktop/final_project/github/Final-Project/src/crawling/economic_index/%ED%95%9C%EA%B5%AD%EC%9D%80%ED%96%89%20API%ED%81%AC%EB%A1%A4%EB%9F%AC.ipynb#X36sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m pythondf_to_DB(df_uskor_exchange, database_name, df_uskor_exchange)\n\u001b[0;32m      <a href='vscode-notebook-cell:/c%3A/Users/USER_20211027/Desktop/final_project/github/Final-Project/src/crawling/economic_index/%ED%95%9C%EA%B5%AD%EC%9D%80%ED%96%89%20API%ED%81%AC%EB%A1%A4%EB%9F%AC.ipynb#X36sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m pythondf_to_DB(df_uskor_exchange, database_name, df_uskor_exchange)\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'pythondf_to_DB' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# 데이터프레임 전송\n",
+    "pythondf_to_DB(df_uskor_exchange, database_name, df_uskor_exchange)\n",
+    "pythondf_to_DB(df_m2, database_name, df_m2)\n",
+    "pythondf_to_DB(df_PPI, database_name, df_PPI)\n",
+    "pythondf_to_DB(df_kr_minus_us_policyratio, database_name, df_kr_minus_us_policyratio)"
+   ]
   }
  ],
  "metadata": {

--- a/src/crawling/economic_index/한국은행 API크롤러.ipynb
+++ b/src/crawling/economic_index/한국은행 API크롤러.ipynb
@@ -126,6 +126,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "df_minimum_wage = pd.read_csv(\"고용노동부_연도별 최저임금_20220805.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def pythondf_to_DB(dataframe, database_name, table_name):\n",
     "\timport pymysql\n",
     "\tfrom sqlalchemy import create_engine\n",
@@ -157,6 +166,14 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DB 전송"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 86,
    "metadata": {},
@@ -174,11 +191,20 @@
     }
    ],
    "source": [
-    "# 데이터프레임 전송\n",
+    "# 미국한국 환율\n",
     "pythondf_to_DB(df_uskor_exchange, database_name, df_uskor_exchange)\n",
+    "\n",
+    "# 연평균 통화량\n",
     "pythondf_to_DB(df_m2, database_name, df_m2)\n",
+    "\n",
+    "# 연평균 생산자 물가\n",
     "pythondf_to_DB(df_PPI, database_name, df_PPI)\n",
-    "pythondf_to_DB(df_kr_minus_us_policyratio, database_name, df_kr_minus_us_policyratio)"
+    "\n",
+    "# 한국 미국 정책금리차\n",
+    "pythondf_to_DB(df_kr_minus_us_policyratio, database_name, df_kr_minus_us_policyratio)\n",
+    "\n",
+    "# 최저임금\n",
+    "pythondf_to_DB(df_minimum_wage, database_name, df_minimum_wage)"
    ]
   }
  ],


### PR DESCRIPTION
# 💡 주요 변경사항
월별 기준금리 1년 단위로 통합, 한국-미국 연평균 금리차 계산

# 🔎 기타